### PR TITLE
[Stomp.client.onreceive] default callback for all MESSAGE | Firefox Support

### DIFF
--- a/src/stomp.js
+++ b/src/stomp.js
@@ -107,8 +107,7 @@
 
     that.connect = function(login_, passcode_, connectCallback, errorCallback) {
       debug("Opening Web Socket...");
-      var Socket = "MozWebSocket" in window ? MozWebSocket : WebSocket;
-      ws = new Socket(url);
+      ws = new WebSocket(url);
       ws.onmessage = onmessage;
       ws.onclose   = function() {
         var msg = "Whoops! Lost connection to " + url;


### PR DESCRIPTION
Some stomp brokers (MorbitQ and Ruby StompServer) doesn't set subscription header (`frame.headers.subscription`) on MESSAGE frame, so StompClient will never call the setted callback. With this fix, user could use `Stomp.client.onreceive` to define a default callback for all MESSAGE frames.

A better approach maybe store topic as indexes for `subscriptions[]` and match `subscriptions[frame.headers.destination]` (in this case a list of callbacks)

<strike>The http://stomp.codehaus.org/Protocol does not say anything about `frame.headers.subscription` be standard </strike>

UPDATE: http://stomp.github.com//stomp-specification-1.1.html#SUBSCRIBE says: The **subscription header will be set** to match the id header of the subscription that is receiving the message. It's **Will**, not **MUST**
