### PR TITLE
support for mozilla firefox

### DIFF
--- a/src/stomp.js
+++ b/src/stomp.js
@@ -104,7 +104,8 @@
 
     that.connect = function(login_, passcode_, connectCallback, errorCallback) {
       debug("Opening Web Socket...");
-      ws = new WebSocket(url);
+      var Socket = "MozWebSocket" in window ? MozWebSocket : WebSocket;
+      ws = new Socket(url);
       ws.onmessage = onmessage;
       ws.onclose   = function() {
         var msg = "Whoops! Lost connection to " + url;


### PR DESCRIPTION
Firefox requires a prefix 'Moz' in order to use websockets
