### PR TITLE
Stomp host/vhost support. Tested with RabbitMQ 2.8.4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ To continuously run tests on file changes:
 The project contains an [chat example](example/chat/index.html) using stomp.js
 to send and receive Stomp messages from a server.
 
+## Use Stomp Vhost / RabbitMQ/AMQP Virtual Hosts
+
+Add the `vhost` parameter during `connect()` :
+
+    client.connect(stompUser, stompPassword, 
+		function() {
+			// connect callback
+		},
+		function() {
+			// error callback
+		},
+		'berbatik_dev'		// vhost here
+	);
+
 ## Todo
 
  * STOMP/1.1 compatibility

--- a/dist/stomp.js
+++ b/dist/stomp.js
@@ -109,7 +109,7 @@ Copyright (C) 2012 FuseSource, Inc. -- http://fusesource.com
       return this.ws.send(out);
     };
 
-    Client.prototype.connect = function(login_, passcode_, connectCallback, errorCallback) {
+    Client.prototype.connect = function(login_, passcode_, connectCallback, errorCallback, vhost_) {
       var klass,
         _this = this;
       if (typeof this.debug === "function") {
@@ -172,7 +172,8 @@ Copyright (C) 2012 FuseSource, Inc. -- http://fusesource.com
         }
         return _this._transmit("CONNECT", {
           login: login_,
-          passcode: passcode_
+          passcode: passcode_,
+          host: vhost_
         });
       };
       return this.connectCallback = connectCallback;

--- a/src/stomp.coffee
+++ b/src/stomp.coffee
@@ -74,7 +74,7 @@ class Client
     @debug?(">>> " + out)
     @ws.send(out)
   
-  connect: (login_, passcode_, connectCallback, errorCallback) ->
+  connect: (login_, passcode_, connectCallback, errorCallback, vhost_) ->
     @debug?("Opening Web Socket...")
     klass = Stomp.WebSocketClass || WebSocket
     @ws = new klass(@url)
@@ -109,7 +109,7 @@ class Client
       errorCallback?(msg)
     @ws.onopen    = =>
       @debug?('Web Socket Opened...')
-      @_transmit("CONNECT", {login: login_, passcode: passcode_})
+      @_transmit("CONNECT", {login: login_, passcode: passcode_, host: vhost_})
     @connectCallback = connectCallback
   
   disconnect: (disconnectCallback) ->


### PR DESCRIPTION
Fixed #14.
