### PR TITLE
Allow ID header to be set manually when subscribing to a destination

### DIFF
--- a/dist/stomp.js
+++ b/dist/stomp.js
@@ -209,9 +209,13 @@ Copyright (C) 2012 FuseSource, Inc. -- http://fusesource.com
       if (headers == null) {
         headers = {};
       }
-      id = "sub-" + this.counter++;
+      if (typeof headers.id === 'undefined' || headers.id.length === 0) {
+        id = "sub-" + this.counter++;
+        headers.id = id;
+      } else {
+        id = headers.id;
+      }
       headers.destination = destination;
-      headers.id = id;
       this.subscriptions[id] = callback;
       this._transmit("SUBSCRIBE", headers);
       return id;

--- a/src/stomp.coffee
+++ b/src/stomp.coffee
@@ -128,9 +128,12 @@ class Client
     @_transmit("SEND", headers, body)
   
   subscribe: (destination, callback, headers={}) ->
-    id = "sub-" + @counter++
+    if typeof(headers.id) == 'undefined' || headers.id.length == 0
+      id = "sub-" + @counter++
+      headers.id = id
+    else
+      id = headers.id
     headers.destination = destination
-    headers.id = id
     @subscriptions[id] = callback
     @_transmit("SUBSCRIBE", headers)
     return id


### PR DESCRIPTION
RabbitMQ's durable topic subscription within it's STOMP plugin uses the ID header on the subscription request in combination with the topic being subscribed to to generate a unique queue name that messages from the topic are dropped into for later retrieval by a reconnecting client.

With the existing code in stomp-websocket the subscription ID is based on the number and order of subscriptions being made. A change in the order that subscriptions are made can cause this ID change thus meaning that messages waiting for this client to reconnect will no longer be accessible.

My change to subscribe will leave an ID header allow if it exists and is longer than 0 characters. Otherwise the old behaviour of generating a subscription ID will be used.
