### PR TITLE
Callback for 'reply-to' messages in temp-queue

### DIFF
--- a/dist/stomp.js
+++ b/dist/stomp.js
@@ -264,7 +264,7 @@
       }
     };
 
-    Client.prototype.send = function(destination, headers, body) {
+    Client.prototype.send = function(destination, headers, body, callback) {
       if (headers == null) {
         headers = {};
       }
@@ -272,6 +272,9 @@
         body = '';
       }
       headers.destination = destination;
+      if (callback) {
+        this.subscriptions[headers['reply-to']] = callback;
+      }
       return this._transmit("SEND", headers, body);
     };
 


### PR DESCRIPTION
Added the ability to define a callback for "reply-to" messages. Example:
var url = 'http://127.0.0.1:15674/stomp';
var ws = new SockJS(url);
var client = Stomp.over(ws);

var on_reply = function(m) {
   alert(m.body);
};

client.connect('guest', 'guest');
client.send('/queue/test', {'reply-to': '/temp-queue/test_temp'}, 'test', on_reply);
