### PR TITLE
accept headers from disconnect

### DIFF
--- a/lib/stomp.js
+++ b/lib/stomp.js
@@ -322,8 +322,11 @@
       };
     };
 
-    Client.prototype.disconnect = function(disconnectCallback) {
-      this._transmit("DISCONNECT");
+    Client.prototype.disconnect = function(disconnectCallback, headers) {
+      if (headers == null) {
+        headers = {};
+      }
+      this._transmit("DISCONNECT", headers);
       this.ws.onclose = null;
       this.ws.close();
       this._cleanUp();

--- a/src/stomp.coffee
+++ b/src/stomp.coffee
@@ -298,8 +298,8 @@ class Client
       @_transmit "CONNECT", headers
 
   # [DISCONNECT Frame](http://stomp.github.com/stomp-specification-1.1.html#DISCONNECT)
-  disconnect: (disconnectCallback) ->
-    @_transmit "DISCONNECT"
+  disconnect: (disconnectCallback, headers={}) ->
+    @_transmit "DISCONNECT", headers
     # Discard the onclose callback to avoid calling the errorCallback when
     # the client is properly disconnected.
     @ws.onclose = null


### PR DESCRIPTION
add a 2nd optional parameter to the disconnect method to pass additional
headers (eg receipt)

fixes #57
