### PR TITLE
Fix content-length on IE8

### DIFF
--- a/lib/stomp.js
+++ b/lib/stomp.js
@@ -48,7 +48,7 @@
 
     Frame.sizeOfUTF8 = function(s) {
       if (s) {
-        return encodeURI(s).split(/%..|./).length - 1;
+        return encodeURI(s).match(/%..|./g).length
       } else {
         return 0;
       }


### PR DESCRIPTION
I noticed that some send requests were failing on IE8 (socks using xhr, rabbitmq webstomp) and when failing content-length was set to -1. The result from split() was an empty list, while working ok in IE9+. Changing split for a global match solved it.
