### PR TITLE
Fixed bower main file path

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,4 +1,4 @@
 {
   "name": "stomp-websocket",
-  "main": "stomp.min.js"
+  "main": "lib/stomp.min.js"
 }


### PR DESCRIPTION
The minified version of the library is found in the lib folder not in the parent folder
