### PR TITLE
Allow CloseEvent if present to be bubbled up.

### DIFF
--- a/src/stomp.coffee
+++ b/src/stomp.coffee
@@ -314,11 +314,11 @@ class Client
             errorCallback?(frame)
           else
             @debug? "Unhandled frame: #{frame}"
-    @ws.onclose   = =>
+    @ws.onclose   = (closeEvent) =>
       msg = "Whoops! Lost connection to #{@ws.url}"
       @debug?(msg)
       @_cleanUp()
-      errorCallback?(msg)
+      errorCallback?(msg, closeEvent)
     @ws.onopen    = =>
       @debug?('Web Socket Opened...')
       headers["accept-version"] = Stomp.VERSIONS.supportedVersions()


### PR DESCRIPTION
In the case of closeEvents being created, expose them to the errorCallBack, which can be useful in diagnosing the type of disconnect.

i.e.
![image](https://cloud.githubusercontent.com/assets/4494301/8072106/4d09aa32-0f09-11e5-8d60-2350d2c7e8d5.png)
 or
![image](https://cloud.githubusercontent.com/assets/4494301/8072129/8bfb2be4-0f09-11e5-866a-8539497bcaf5.png)
